### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/index.py
+++ b/index.py
@@ -17,7 +17,7 @@ app.index_string = f"""
 <html>
     <head>
         <script async defer
-          src="https://umami.snap.uaf.edu/umami.js"
+          src="https://umami.snap.uaf.edu/script.js"
           data-website-id="f942d158-bdc3-4022-9f8e-eeee900b6dad"
           data-domains="snap.uaf.edu"
           data-do-not-track="true"


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `index.py` to:

```
<script async defer
  src="http://localhost:9999/script.js"
  data-website-id="f942d158-bdc3-4022-9f8e-eeee900b6dad"
  data-do-not-track="true"
></script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/f942d158-bdc3-4022-9f8e-eeee900b6dad